### PR TITLE
Fixes with normalizes ipcw weights

### DIFF
--- a/R/tmle-eif_ipcw.R
+++ b/R/tmle-eif_ipcw.R
@@ -35,7 +35,7 @@ tmle_eif_ipcw <- function(fluc_mod_out,
   # compute TMLE of the treatment shift parameter
   param_obs_est <- rep(0, length(Delta))
   param_obs_est[Delta == 1] <- ipc_weights_norm * fluc_mod_out$Qn_shift_star
-  psi <- mean(param_obs_est)
+  psi <- sum(param_obs_est)
 
   # compute the efficient influence function (EIF) / canonical gradient (D*)
   eif <- rep(0, length(Delta))

--- a/R/tmle-txshift.R
+++ b/R/tmle-txshift.R
@@ -51,7 +51,7 @@ tmle_txshift <- function(W,
                          V = NULL,
                          delta = 0,
                          fluc_method = c("standard", "weighted"),
-                         eif_tol = 1e-9,
+                         eif_tol = 1/length(Y),
                          max_iter = 1e4,
                          ipcw_fit_args = list(
                            fit_type = c("glm", "sl"),
@@ -203,10 +203,13 @@ tmle_txshift <- function(W,
       )
 
       # overwrite/update quantities to be used in next iteration
+      # NOTE FOR NIMA: don't know if you have a function to do this 
+      # rescaling or not
+      ymin <- min(Y); ymax <- max(Y)
       Qn_estim_use <- data.table::as.data.table(
         list(
-          ipcw_tmle_comp$fluc_mod_out$Qn_noshift_star,
-          ipcw_tmle_comp$fluc_mod_out$Qn_shift_star
+          (ipcw_tmle_comp$fluc_mod_out$Qn_noshift_star - ymin)/(ymax - ymin),
+          (ipcw_tmle_comp$fluc_mod_out$Qn_shift_star - ymin)/(ymax - ymin)
         )
       )
       data.table::setnames(Qn_estim_use, names(Qn_estim))

--- a/vignettes/ipcw_txshift.Rmd
+++ b/vignettes/ipcw_txshift.Rmd
@@ -13,6 +13,7 @@ vignette: >
 
 ```{r, echo=FALSE}
 options(scipen = 999)
+install.packages("~/Dropbox/R/txshift/", type = "source", repos = NULL)
 # library(here)
 # install.packages(here(), type = "source", repos = NULL)
 # devtools::install_github("nhejazi/condensier", ref = "weights")
@@ -86,6 +87,7 @@ tmle_glm_shift_1 <- tmle_txshift(W = W, A = A, Y = Y,
                                  delta = 0.5,
                                  fluc_method = "standard",
                                  max_iter = 10,
+                                 eif_tol = 1/length(Y),
                                  ipcw_fit_args = list(fit_type = "glm",
                                                       glm_formula = "Delta ~ ."),
                                  g_fit_args = list(fit_type = "glm", nbins = 35,


### PR DESCRIPTION
I think these small fixes should do the trick. The fixes are as follows:

- change `mean` to `sum` when computing the parameter estimate (we can discuss on our call why this is needed. 
- change the default mean of EIF tolerance to be `1/n` -- we only want to iterate until we get something smaller than c_n, where we choose c_n such that it's o(n^{-1/2}), e.g., `1/sqrt(n)` or `1/n`. 
- the function for estimating the outcome regression appears to scale the results to be between 0 and 1, while the function for fluctuating these estimates return unscaled outcome regression values. Thus, when iterating unscaled values were being fed back into the fluctuation function, which was expecting scaled values. So I added scaled values to the updating of `Qn_estim_use`

Based on a few by-hand runs on my computer, things appear to be giving sane answers with these fixes. 

A couple other notes of things we may want to study in simulation that we might want to add:
- Maybe good to keep track of how `psi` changes with iteration (including an initial estimate of psi)
- Might as well also keep track of the variance estimate too, so we can examine e.g., how well the first step tmle performs vs. the full blown iterative
- Good idea to keep track of the number of iterations