### PR TITLE
fix inefficient parameter calculation

### DIFF
--- a/R/tmle-eif_std.R
+++ b/R/tmle-eif_std.R
@@ -24,14 +24,19 @@
 tmle_eif <- function(fluc_mod_out,
                      Hn,
                      Y,
+                     Delta = C,
                      ipc_weights = rep(1, length(Y)),
+                     ipc_weights_norm = rep(1, length(Y)),
                      tol_eif = 1e-7) {
   # compute TMLE of the treatment shift parameter
-  psi <- mean(ipc_weights * fluc_mod_out$Qn_shift_star)
+  param_obs_est <- rep(0, length(Delta))
+  param_obs_est[Delta == 1] <- ipc_weights_norm * fluc_mod_out$Qn_shift_star
+  psi <- sum(param_obs_est)
 
   # compute the efficient influence function (EIF) / canonical gradient (D*)
-  eif <- ipc_weights * (Hn$noshift * (Y - fluc_mod_out$Qn_noshift_star) +
-    (fluc_mod_out$Qn_shift_star - psi))
+  eif <- rep(0, length(Delta))
+  eif[Delta == 1] <- ipc_weights * (Hn$noshift *
+    (Y - fluc_mod_out$Qn_noshift_star) +(fluc_mod_out$Qn_shift_star - psi))
 
   # sanity check on EIF
   # NOTE: EIF ~ N(0, V(D(P)(o))), so mean(EIF) ~= 0

--- a/R/tmle-txshift.R
+++ b/R/tmle-txshift.R
@@ -170,6 +170,7 @@ tmle_txshift <- function(W,
       ipcw_out <- do.call(est_ipcw, ipcw_estim_args)
     }
     cens_weights <- ipcw_out$ipc_weights
+    cens_weights_norm <- cens_weights / sum(cens_weights)
     data_internal <- data.table::as.data.table(list(W, A = A, C = C, Y = Y)) %>%
       dplyr::filter(C == 1) %>%
       dplyr::select(-C) %>%
@@ -337,7 +338,9 @@ tmle_txshift <- function(W,
       fluc_mod_out = fitted_fluc_mod,
       Hn = Hn_estim,
       Y = data_internal$Y,
+      Delta = C, 
       ipc_weights = cens_weights,
+      ipc_weights_norm = cens_weights_norm,
       tol_eif = eif_tol
     )
   }


### PR DESCRIPTION
This PR fixes the computation of the target parameter estimate for the inefficent implementation. It basically makes `tmle_eif` look more like `tmle_eif_ipcw` in how it computes the parameter estimate and EIF. By-hand simulations show that this seems to fix the wonky estimates seen in earlier simulations. 