### PR TITLE
Estimate Q on original scale

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # txshift 0.3.9
 
+As of August 2023:
+* Txshift has been modified to estimate Q on the original scale of the outcome,
+instead of scaling Y before estimating Q. This is helpful when the outcome is a 
+count and some of the algorithms in the SL library only handle non-negative integers.
+* A new argument `glm_family` has been added to `est_Q()` to specify the family
+when a glm is used to estimate Q.
+* @Lauren-EylerDang, #70
+
 As of May 2023:
 * A new argument `bound` has been added to `bound_propensity()` to specify the
   lower tolerated limit of generalized propensity score estimates. Estimates

--- a/R/fit_mechanisms.R
+++ b/R/fit_mechanisms.R
@@ -335,6 +335,7 @@ est_g_cens <- function(C_cens,
 #'  for fitting a (generalized) linear model via \code{\link[stats]{glm}}.
 #' @param sl_learners Object containing a set of instantiated learners from the
 #'  \pkg{sl3}, to be used in fitting an ensemble model.
+#' @param glm_family The family to be used for glm estimation of Q.
 #'
 #' @importFrom stats glm as.formula predict
 #' @importFrom data.table as.data.table setnames copy set
@@ -366,7 +367,7 @@ est_Q <- function(Y,
   }
 
   # scale the outcome for logit transform
-  # don't do this before prediction
+  # don't scale before prediction
   #y_star <- scale_to_unit(vals = Y)
 
   # generate the data objects for fitting the outcome regression
@@ -434,14 +435,12 @@ est_Q <- function(Y,
       data = data_in[C_cens == 1, ],
       covariates = c("C_cens", "A", names_W),
       outcome = "Y",
-      #outcome_type = "quasibinomial",
       weights = "ipc_weights"
     )
     task_noshift_nocens <- sl3::sl3_Task$new(
       data = data_in[, C_cens := 1],
       covariates = c("C_cens", "A", names_W),
       outcome = "Y",
-      #outcome_type = "quasibinomial",
       weights = "ipc_weights"
     )
 
@@ -450,7 +449,6 @@ est_Q <- function(Y,
       data = data_in_shifted,
       covariates = c("C_cens", "A", names_W),
       outcome = "Y",
-      #outcome_type = "quasibinomial",
       weights = "ipc_weights"
     )
 

--- a/man/est_Q.Rd
+++ b/man/est_Q.Rd
@@ -13,6 +13,7 @@ est_Q(
   samp_weights = rep(1, length(Y)),
   fit_type = c("sl", "glm"),
   glm_formula = "Y ~ .",
+  glm_family = "binomial",
   sl_learners = NULL
 )
 }
@@ -44,6 +45,8 @@ provided. Consult the documentation of \pkg{sl3} for details.}
 
 \item{glm_formula}{A \code{character} giving a \code{\link[stats]{formula}}
 for fitting a (generalized) linear model via \code{\link[stats]{glm}}.}
+
+\item{glm_family}{The family to be used for glm estimation of Q.}
 
 \item{sl_learners}{Object containing a set of instantiated learners from the
 \pkg{sl3}, to be used in fitting an ensemble model.}


### PR DESCRIPTION
Hi Nima,

I am working on a project with a count outcome, and some of the algorithms my collaborators want to consider in the SL library only handle non-negative integers. For this reason, I modified the est_Q function to estimate Q on the original outcome scale (instead of scaling Y before estimating Q). If you find this modification helpful, please consider my pull request. 

Thanks,
Lauren